### PR TITLE
Add SimpleDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-npm-debug.log
+*.log
 node_modules/

--- a/bin/amz.js
+++ b/bin/amz.js
@@ -1,0 +1,120 @@
+var args = process.argv.slice(2)
+var argsNeeded = true
+var commands = {
+    sdb: {
+        commands: {
+            domain: {
+                commands: {
+                    add: {
+                        action: function() {
+                            var name = requiredArg('Requires domain name to add')
+                            db().createDomain(name, function(err, d) {
+                                exitOnError(err)
+                                console.log(JSON.stringify(d, null, 2))
+                            })
+                            console.log('adding domain', args[0])
+                        }
+                    },
+                    list: {
+                        action: function() {
+                            db().listDomains(function(err, domains) {
+                                exitOnError(err)
+                                if (domains.length < 10) {
+                                    console.log(JSON.stringify(domains))
+                                } else {
+                                    console.log(JSON.stringify(domains, null, 2))
+                                }
+                            })
+                        }
+                    },
+                    info: {
+                        action: function() {
+                            var name = requiredArg('Requires domain name to get info')
+                            db().getDomain(name).metadata(function(err, info) {
+                                exitOnError(err)
+                                console.log(JSON.stringify(info, null, 2))
+                            })
+                        }
+                    },
+                    rm: {
+                        action: function() {
+                            var name = requiredArg('Requires domain name to remove')
+                            db().getDomain(name).del(function(err, info) {
+                                exitOnError(err)
+                                console.log(JSON.stringify(info, null, 2))
+                            })
+                        }
+                    }
+                }
+            }
+        }
+    },
+    version: {
+        action: function() {
+            console.log('amz', '0.0.1')
+        }
+    }
+}
+
+while(argsNeeded && args.length > 0) {
+    var arg = args.shift()
+    if (commands[arg]) {
+        var cmd = commands[arg]
+        if (cmd.action) {
+            cmd.action()
+            argsNeeded = false
+        } else {
+            commands = cmd.commands
+        }
+    } else {
+        console.log('Unsupported command', arg, 'should be', currentCommands())
+        process.exit(1)
+    }
+}
+
+if (argsNeeded) {
+    console.log('You must supply a command', currentCommands())
+}
+
+// -------------------------------------------------------
+// Utilities
+// -------------------------------------------------------
+
+// List the currently available commands
+function currentCommands() {
+    var current = []
+    for (var c in commands) {
+        if (commands.hasOwnProperty(c)) {
+            current.push(c)
+        }
+    }
+    return current
+}
+
+// Obtain a SimpleDB object with the provided options
+function exitOnError(err) {
+    if (err) {
+        console.error(err)
+        process.exit(1)
+    }
+}
+
+// Check for required argument
+function requiredArg(msg) {
+    if (args.length == 1) {
+        return args[0]
+    } else {
+        console.error(msg)
+        process.exit(1)
+    }
+}
+
+// Obtain AWS SDK options
+function options() {
+    return {region: process.env['AWS_REGION'] || 'us-east-1'}
+}
+
+// Obtain SimpleDB database
+function db() {
+    return require('../lib/simpledb').createDB(options())
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,14 +24,21 @@ exports.load = function(done) {
             request({url: 'http://169.254.169.254/latest/meta-data/instance-id', timeout: 500}, function (error, response, body) {
                 if (!error && response.statusCode == 200) {
                     conf.instance = body
-                    done(null, conf)
+                    request({url: 'http://169.254.169.254/latest/meta-data/placement/availability-zone', timeout: 500}, function(error, response, body) {
+                        if (!error && response.statusCode == 200) {
+                            conf.region = body
+                            done(null, conf)
+                        } else {
+                            done(null)
+                        }
+                    })
                 } else {
                     done(null)
                 }
             })
         } else {
             // We must be in development mode - we can't access the meta-data server
-            done(null, {mode: 'dev', api: '127.0.0.1', instance: 'node'})
+            done(null, {mode: 'dev', api: '127.0.0.1', instance: 'node', region: 'us-east-1'})
         }
     })
 }

--- a/lib/log.js
+++ b/lib/log.js
@@ -33,7 +33,6 @@ exports.getLog = function(pkg) {
         ]
     }
     log = bunyan.createLogger(config)
-    log.info({version: pkg.version || '---'},'Starting')
     return log
 }
 

--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -1,10 +1,11 @@
 var log = require('./log').getLog().child({'pkg':'sdb'})
+var aws = require('aws-sdk')
 
 // Simplify the SimpleDB API so we isolate any AWS complexity here.
 
 // Represents a simplified SimpleDB database representation.
-function SimpleDB() {
-
+function SimpleDB(opt) {
+    this.db = new aws.SimpleDB(opt)
 }
 
 // Create a domain with the gven name (see SimpleDB for exact limits for names).
@@ -25,15 +26,25 @@ function SimpleDB() {
 // })
 // ```
 SimpleDB.prototype.createDomain = function(name, done) {
-    return this.db.createDomain({DomainName: name}, done)
+    if (done) {
+        this.db.createDomain({DomainName: name}, done)
+    } else {
+        this.db.createDomain({DomainName: name}).send()
+    }
 }
 
-SimpleDB.prototype.listDomains = function() {
-
+SimpleDB.prototype.listDomains = function(done) {
+    this.db.listDomains({}, function(err, data) {
+        if (err) {
+            return done(err)
+        } else {
+            return done(null, data.DomainNames)
+        }
+    })
 }
 
 SimpleDB.prototype.getDomain = function(name) {
-    return new Domain(name)
+    return new Domain(this.db, name)
 }
 
 SimpleDB.prototype.select = function(query) {
@@ -41,7 +52,8 @@ SimpleDB.prototype.select = function(query) {
 }
 
 // A SimpleDB Domain object. Most actions should be performed on the domain.
-function Domain(name) {
+function Domain(db, name) {
+    this.db = db
     this.domain = name
 }
 
@@ -49,23 +61,42 @@ Domain.prototype.getAttributes = function() {
 
 }
 
-Domain.prototype.putAttributes = function(item, data) {
-    log.info({domain: this.domain, item: item, data: data})
+Domain.prototype.putAttributes = function(item, data, done) {
+    var params = {
+        DomainName: this.domain,
+        ItemName: item,
+        Attributes: []
+    }
+    for (var name in data) {
+        if (data.hasOwnProperty(name)) {
+            var val = data[name]
+            if (typeof val == 'object') {
+                val = JSON.stringify(val)
+            }
+            params.Attributes.push({Name: name, Value: val, Replace: true})
+        }
+    }
+    log.info({params: params})
+    if (done) {
+        this.db.putAttributes(params, done)
+    } else {
+        this.db.putAttributes(params).send()
+    }
 }
 
 Domain.prototype.deleteAttributes = function() {
 
 }
 
-Domain.prototype.metadata = function() {
-
+Domain.prototype.metadata = function(done) {
+    this.db.domainMetadata({DomainName: this.domain}, done)
 }
 
-Domain.prototype.deleteDomain = function() {
-
+Domain.prototype.del = function(done) {
+    this.db.deleteDomain({DomainName: this.domain}, done)
 }
 
 exports.createDB = function(options) {
     var opt = options || {}
-    return new SimpleDB()
+    return new SimpleDB(opt)
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "aws-sdk": "latest",
         "bunyan":  "latest",
+        "commander": "latest",
         "request": "latest",
         "restify": "latest"
     },

--- a/server.js
+++ b/server.js
@@ -37,7 +37,7 @@ config.load(function(err, conf) {
     apiServer.start(function(err, c) {
         log.info(c, 'api started')
         // Advertize the API in SimpleDB
-        var db = simpledb.createDB()
+        var db = simpledb.createDB({region: conf.region})
         var domain = db.getDomain('cluster')
         domain.putAttributes(c.instance, c, function(err) {
             if (err) {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@
 var pkg = require('./package.json')
 var log = require('./lib/log').getLog(pkg)
 
+log.info({version: pkg.version || '---'},'Starting')
+
 // Now load app packages
 var config = require('./lib/config')
 var api = require('./lib/api')

--- a/test/simpledb.js
+++ b/test/simpledb.js
@@ -1,0 +1,14 @@
+var sdb = require('../lib/simpledb')
+var should = require('should')
+
+describe('SimpleDB', function() {
+    describe('List Domains', function() {
+        it('should list domains on an account', function(done) {
+            var db = sdb.createDB({region:'us-east-1'})
+            db.listDomains(function(err, domains) {
+                console.log('found domains', err, domains)
+                done(err)
+            })
+        })
+    })
+})


### PR DESCRIPTION
Implement SimpleDB integration.

Includes command line tool to manage SimpleDB. AWS doesn’t provide any tooling around SimpleDB and you can’t even see it in the console.
